### PR TITLE
[WIP] feat: adding migration guides

### DIFF
--- a/content/migrations/migrations.mdx
+++ b/content/migrations/migrations.mdx
@@ -1,0 +1,66 @@
+---
+name: mobx-react → lite
+route: /migration-guides/mobx-react-lite
+menu: Migration guides
+---
+
+# Migration guides
+
+## From mobx-react to mobx-react-lite
+
+_TODO(?): quick description of differences (or link)._
+
+### Should I migrate?
+
+_TODO: reasons for which developers could or should migrate._
+* One reason could be that in a future major version, [React will drop the legacy context API](https://reactjs.org/docs/context.html#legacy-api).
+
+### Case 1: app bootstrapping, context setup
+
+A typical pattern is to create a root store that could be provided to any component that needs it.
+
+#### Before (mobx-react)
+
+Bootstrapping and setting up the provider.
+```js
+import * as mobx from 'mobx'
+import App from './App'
+import RootStore from './stores/RootStore'
+import {Provider} from 'mobx-react'
+
+const rootStore = new RootStore()
+
+// AppContainer is a necessary wrapper component for HMR
+const render = (Component) => {
+  reactDom.render(
+    <Provider rootStore={rootStore}>
+      <Component />
+    </Provider>
+    document.getElementById('root')
+  )
+}
+
+render(App)
+```
+
+Then consuming the root store in a component
+```js
+import {observer, inject} from 'mobx-react'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+export function App (props) {
+  const {rootStore} = props
+  return (
+      <div>
+        My App {rootStore.value}
+      </div>
+  )
+}
+
+export default inject('rootStore')(observer(App))
+```
+
+#### After (mobx-react-lite)
+
+_TODO_


### PR DESCRIPTION
Note: this is work in progress, open to discussion, etc.

## What is this about: documenting possible migration guides
Guides about possible migrations in the mobx react ecosystem would be useful to save people's time. Sometimes it can be a full article, and sometimes it can be a simple link to another page of the docs as patterns evolve and will be documented in other sections.

This PR in particular wants to start with `mobx-react` vs `mobx-react-lite` and the new context API.

## What prompted the PR
mobx-react-lite readme mentions ["why no provider inject"](https://github.com/mobxjs/mobx-react-lite#why-no-providerinject). Having a more complete example would be helpful as more and more people will upgrade or write new apps with a major React version in the future but the legacy context API will be dropped. 

## Todos
- [ ] The equivalent / replacement of typical app bootstrapping with a root store in top level component.
