### PR TITLE
Update migration.mdx

### DIFF
--- a/content/recipes/migration.mdx
+++ b/content/recipes/migration.mdx
@@ -106,7 +106,7 @@ const UserOrderInfo = observer(() => {
 However, be warned here. If you would attempt to destructure `data`, you would lose the reactivity. That is the general problem of MobX and many got burned by it. An alternative and safer approach can look like following.
 
 ```tsx
-import { useObserver } from 'mobx-react'
+import { useObserver } from 'mobx-react-lite'
 function useUserData() {
   const { user, order } = useStores()
   return useObserver(() => ({

--- a/content/recipes/migration.mdx
+++ b/content/recipes/migration.mdx
@@ -106,7 +106,8 @@ const UserOrderInfo = observer(() => {
 However, be warned here. If you would attempt to destructure `data`, you would lose the reactivity. That is the general problem of MobX and many got burned by it. An alternative and safer approach can look like following.
 
 ```tsx
-import { useObserver } from 'mobx-react-lite'
+// use mobx-react@6.1.2 or `mobx-react-lite`
+import { useObserver } from 'mobx-react'
 function useUserData() {
   const { user, order } = useStores()
   return useObserver(() => ({


### PR DESCRIPTION
I've reported this issue https://github.com/mobxjs/mobx-react/issues/755.
As I understand, the `useObserver` belongs to `mobx-react-lite` package.