### PR TITLE
remove superfluous useCallback

### DIFF
--- a/content/recipes/context.mdx
+++ b/content/recipes/context.mdx
@@ -84,16 +84,16 @@ import { useStore } from '../../../store'
 
 export const FriendsMaker = observer(() => {
   const store = useStore()
-  const onSubmit = React.useCallback(({ name, favorite, single }) => {
+  const onSubmit = ({ name, favorite, single }) =>
     store.makeFriend(name, favorite, single)
-  }, [])
+
   return (
-    <Form onSubmit={onSubmit}>
+    <form onSubmit={onSubmit}>
       Total friends: {store.friends.length}
       <input type="text" id="name" />
       <input type="checkbox" id="favorite" />
       <input type="checkbox" id="single" />
-    </Form>
+    </form>
   )
 })
 ```


### PR DESCRIPTION
When people see `useCallback` used like this without explanation for why, they'll just assume they should put all callbacks within a `useCallback` which is not a good thing.