### PR TITLE
fix: adds missing comma in docs

### DIFF
--- a/content/recipes/context.mdx
+++ b/content/recipes/context.mdx
@@ -25,7 +25,7 @@ export type TFriend = {
 export function createStore() {
   // note the use of this which refers to observable instance of the store
   return {
-    friends: [] as TFriend[]
+    friends: [] as TFriend[],
     makeFriend(name, isFavorite = false, isSingle = false) {
       const oldFriend = this.friends.find(friend => friend.name === name)
       if (oldFriend) {


### PR DESCRIPTION
Adds missing required comma after `friends: [] as TFriend[]`.