### PR TITLE
Add beginner friendly documentation

### DIFF
--- a/content/basics/basics.mdx
+++ b/content/basics/basics.mdx
@@ -7,15 +7,17 @@ import { Playground } from 'docz'
 
 # Basic Introduction
 
-MobX lets you create observable state. This library, `mobx-react` integrates it
-with React. It provides a way for you to create React components that respond
-to MobX state changes.
+[MobX](https://mobx.js.org/README.html) lets you create observable state. This
+library, `mobx-react` integrates it with React. It provides a way for you to
+create React components that respond to MobX state changes.
 
-> Frameworks such as `mobx-state-tree` and `mobx-keystone` exist that build on
+> Frameworks such as [mobx-state-tree](https://mobx-state-tree.js.org) and
+> [mobx-keystone](https://mobx-keystone.js.org/) build on
 > top of MobX to offer a higher-level way to create observable models. These models
 > give you additional properties, such as automatic serialization to JSON. This
 > introduction uses plain MobX models. The principles of React
-> integration are the same, as these libraries are built with MobX.
+> integration are the same for these advanced libraries are the same
+> as they are also built with MobX.
 
 ## MobX models
 

--- a/content/basics/basics.mdx
+++ b/content/basics/basics.mdx
@@ -15,7 +15,9 @@ to MobX state changes.
 > top of MobX to offer a higher-level way to create observable models. These models
 > give you additional properties, such as automatic serialization to JSON. This
 > introduction uses plain MobX models. The principles of React
-> integration are the same.
+> integration are the same, as these libraries are built with MobX.
+
+## MobX models
 
 Let's consider MobX models for animals in a zoo, where each animal
 has a certain amount of energy. If the energy is below 50, the animal
@@ -67,13 +69,10 @@ class Zoo {
 }
 ```
 
-We haven't used anything except plain MobX yet in this example. Now let's
-create a React component to show information for an animal:
+## A React component that observes
 
-> These examples work with `mobx-react-lite` as well. `mobx-react` expands
-> `mobx-react-lite` to have support for React class components as well.
-> If you are creating a new project that only uses function components, you
-> can use `mobx-react-lite`.
+We haven't used anything except plain MobX in this example. Now let's
+create a React component to show information for an animal:
 
 ```tsx
 import { Component } from 'react'
@@ -89,6 +88,11 @@ const AnimalView = observer(({ animal }: { animal: Animal }) => {
 })
 ```
 
+> These examples work with `mobx-react-lite` too. `mobx-react` expands
+> `mobx-react-lite` to have support for React class components. If you are
+> creating a new project that only uses React function components, you can use
+> `mobx-react-lite`.
+
 Let's create an instance of `Animal`:
 
 ```tsx
@@ -103,13 +107,18 @@ We can now render `fred`:
 
 The only special thing that `AnimalView` does compared to a normal React
 function component is that it is wrapped in `observer` from `mobx-react`. This
-makes `AnimalView` automatically rerender itself, if anything that it observes
+makes `AnimalView` automatically re-render itself if anything that it observes
 changes. In this case the observable information is the computed property
-`isHungry`, which in turn it based on the observable property `energy`. So only
-if `isHungry` changes, `AnimalView` automatically rerenders itself.
+`isHungry`, which in turn it based on the observable property `energy`.
+`AnimalView` automatically re-renders itself only if `isHungry` changes. You
+don't need to do anything else to make that happen.
 
-Wrapping a component in `observer` is cheap, so it's recommended to just wrap
-all your components in `observer` in a `mobx-react` application.
+When you wrap your React component in `observer`, it tracks any observable
+property or object you access during rendering it, and reacts to any changes to
+these. It won't react to any changes in observable properties you _don't_
+directly or indirectly use during rendering.
+
+## When do observers observe?
 
 Note that MobX can only observe properties, not simple values like a `string`
 or a `number`. So if you write your component to only receive simple values, it
@@ -141,10 +150,17 @@ const NonObservingAnimalView = observer(
 ```
 
 The component `NonObservingAnimalView` works perfectly if it is used within
-another component that is also an observer, but it will re-render each and
-every time, because MobX cannot see whether `name`, `species` or `isHungry` are
-changed. Our original `AnimalView` _does_ observe it, because it can track
-property accesses.
+another component that receives an `Animal` instance and is also an observer,
+but it re-render each and every time, because MobX cannot see whether
+`name`, `species` or `isHungry` are changed. Our original `AnimalView` _does_
+observe it, because it can track property accesses.
+
+Wrapping a component in `observer` is cheap, so if you use MobX with react,
+it's recommended to just wrap all your components in `observer`, even if the
+component does not use any observable information yet. There is no need
+distinguish between React components that observe and do not observe in this.
+
+## Observable arrays
 
 MobX does support observable arrays, observable
 objects and observable maps, so those _can_ be observed for changes by
@@ -167,10 +183,6 @@ const AnimalsView = observer(({ animals }: { animals: Animal[] }) => {
 })
 ```
 
-If we invoke this with an observable array of animals, the React component
-automatically re-renders each time the array changes (by adding or removing
-items) or if any item in that array itself changes.
-
 Instances of our `Zoo` class have an `animals` property that is observable, so
 let's use that:
 
@@ -187,3 +199,127 @@ We can now render our animals:
 ```tsx
 <AnimalsView animals={zoo.animals} />
 ```
+
+`AnimalsView` automatically re-renders itself whenever you change the array, in
+this case by using `Zoo.addAnimal`. The individual `AnimalView` re-renders
+itself as before when any observed properties the underlying object change,
+which in this case is its `isHungry` status.
+
+## Local component state with `useLocalStore`
+
+So far we have discussed observable model state, where the models live outside
+of the React components. It is useful to have component-specific state however.
+This is state that only makes sense within that component, is typically very UI
+specific, and there is no reason to specify this part of your application's
+models.
+
+This is useful for "temporary data", such as for instance the text that a user
+is currently entering into an input widget. If the user then performs a special
+action such as pressing a button' this text may be saved into an actual model
+instance. And depending on your application's architecture you can even manage
+all your state this way.
+
+This is the MobX equivalent of component state as you'd use with the `useState`
+hook or the `setState` method in case of class components. Unlike React the
+`useState` hook, the MobX local store is observable.
+
+Here is an example where we add an animal to a zoo using a form:
+
+```tsx
+import { Component } from 'react'
+import { observer } from 'mobx-react'
+
+const AddAnimalView = observer(({ zoo }: { zoo: Zoo }) => {
+  const local = useLocalStore(() => ({
+    name: '',
+    species: '',
+  }))
+
+  const handleAdd = () => {
+    zoo.addAnimal(new Animal(local.name, local.species))
+    // clear input again after adding
+    local.name = ''
+    local.species = ''
+  }
+
+  const handleChangeName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    local.name = e.target.value
+  }
+
+  const handleChangeSpecies = (e: React.ChangeEvent<HTMLInputElement>) => {
+    local.species = e.target.value
+  }
+
+  return (
+    <div>
+      <div>
+        Name:
+        <input type="text" value={local.name} onChange={handleChangeName} />
+      </div>
+      <div>
+        Species:
+        <input
+          type="text"
+          value={local.species}
+          onChange={handleChangeSpecies}
+        />
+      </div>
+      <button onClick={handleAdd}>Add animal</button>
+    </div>
+  )
+})
+```
+
+Here we define an object called `local` with two observable properties, `name`
+and `species`. We use the React [controlled
+components](https://reactjs.org/docs/forms.html#controlled-components)
+technique to allow the user to edit these properties. As you can see, this
+simply involves mutating the local state directly. We also have an `Add animal`
+button which uses the local state to modify the zoo using the `addAnimal`
+action. It then needs to reset the local state again to allow the user to
+enter another animal.
+
+XXX interaction with strict mode, see https://github.com/mobxjs/mobx-react-lite/issues/235
+if strict mode is the recommended story, what would we recommend instead of
+use useLocalStore?
+
+## Application organization
+
+In these examples we described how you can create observer React components
+that take observable instances as props, and this is a good pattern to follow.
+
+But where do you get these props from? Often they can be retrieved from
+_other_ observable objects. Let's consider `ZooView`:
+
+```tsx
+import { Component } from 'react'
+import { observer } from 'mobx-react'
+
+const ZooView = observer(({ zoo }: { zoo: Zoo }) => {
+  return (
+    <div>
+      <AnimalsView animals={zoo.animals} />
+      <AddAnimalView zoo={zoo} />
+    </div>
+  )
+})
+```
+
+Where does `AnimalsView` get its `animals` prop from? From the `zoo` in
+`ZooView`. Where does `AnimalView` get its `animal` prop? From the each animal
+in the `AnimalsView`. We also pass `zoo` into `AddAnimalView` directly.
+
+But where would we put the `zoo`? One simple approach is to make it a global in
+your application, and simply import it when you need it.
+
+Often this is sufficient. Consider a `Locale` MobX model that describes information
+about your site's Locale. You can simply maintain the current locale as
+a global and import it wherever you need it.
+
+As an alternative you can create an observable model as part of component state
+and then pass it along as a prop.
+
+If you need to have access to a MobX model instance in many components but you
+still want different sections of your UI to use a _different_ instance, you can
+pass in a MobX model instance with [React's context
+mechanism](https://reactjs.org/docs/context.html).

--- a/content/basics/basics.mdx
+++ b/content/basics/basics.mdx
@@ -1,0 +1,190 @@
+---
+name: Basics
+route: /basics
+---
+
+import { Playground } from 'docz'
+
+# Basic Introduction
+
+MobX lets you create observable state. This library, `mobx-react` integrates it
+with React. It provides a way for you to create React components that respond
+to MobX state changes.
+
+> Frameworks such as `mobx-state-tree` and `mobx-keystone` exist that build on
+> top of MobX to offer a higher-level way to create observable models. These models
+> give you additional properties, such as automatic serialization to JSON. This
+> introduction uses plain MobX models. The principles of React
+> integration are the same.
+
+Let's consider MobX models for animals in a zoo, where each animal
+has a certain amount of energy. If the energy is below 50, the animal
+is hungry. Animals can be fed to increase their energy levels:
+
+> These code examples use TypeScript. If you use plain JavaScript you
+> can skip the type declarations.
+
+```tsx
+import { observable, action, computed } from 'mobx'
+
+class Animal {
+  name: string
+  species: string
+  @observable energy: number
+
+  constructor(name: string, species: string, energy: number = 100) {
+    this.name = name
+    this.species = species
+    this.energy = energy
+  }
+
+  @action
+  timePasses() {
+    this.energy -= 10
+  }
+
+  @action
+  feed() {
+    this.energy += 50
+    if (this.energy > 100) {
+      this.energy = 100
+    }
+  }
+
+  @computed
+  get isHungry() {
+    return this.energy < 50
+  }
+}
+
+class Zoo {
+  @observable animals: Animal[] = []
+
+  @action
+  addAnimal(animal: Animal) {
+    this.animals.push(animal)
+  }
+}
+```
+
+We haven't used anything except plain MobX yet in this example. Now let's
+create a React component to show information for an animal:
+
+> These examples work with `mobx-react-lite` as well. `mobx-react` expands
+> `mobx-react-lite` to have support for React class components as well.
+> If you are creating a new project that only uses function components, you
+> can use `mobx-react-lite`.
+
+```tsx
+import { Component } from 'react'
+import { observer } from 'mobx-react'
+
+const AnimalView = observer(({ animal }: { animal: Animal }) => {
+  return (
+    <div>
+      {animal.name} is of species {animal.species} and is{' '}
+      {animal.isHungry ? 'hungry' : 'not hungry'}.
+    </div>
+  )
+})
+```
+
+Let's create an instance of `Animal`:
+
+```tsx
+const fred = new Animal('Fred', 'hippo')
+```
+
+We can now render `fred`:
+
+```tsx
+<AnimalView animal={fred} />
+```
+
+The only special thing that `AnimalView` does compared to a normal React
+function component is that it is wrapped in `observer` from `mobx-react`. This
+makes `AnimalView` automatically rerender itself, if anything that it observes
+changes. In this case the observable information is the computed property
+`isHungry`, which in turn it based on the observable property `energy`. So only
+if `isHungry` changes, `AnimalView` automatically rerenders itself.
+
+Wrapping a component in `observer` is cheap, so it's recommended to just wrap
+all your components in `observer` in a `mobx-react` application.
+
+Note that MobX can only observe properties, not simple values like a `string`
+or a `number`. So if you write your component to only receive simple values, it
+does not benefit from observability:
+
+```tsx
+import { Component } from 'react'
+import { observer } from 'mobx-react'
+
+// Uses observer() but does not benefit from observability
+const NonObservingAnimalView = observer(
+  ({
+    name,
+    species,
+    isHungry,
+  }: {
+    name: string
+    species: string
+    isHungry: boolean
+  }) => {
+    return (
+      <div>
+        {name} is of species {species} and is{' '}
+        {isHungry ? 'hungry' : 'not hungry'}.
+      </div>
+    )
+  },
+)
+```
+
+The component `NonObservingAnimalView` works perfectly if it is used within
+another component that is also an observer, but it will re-render each and
+every time, because MobX cannot see whether `name`, `species` or `isHungry` are
+changed. Our original `AnimalView` _does_ observe it, because it can track
+property accesses.
+
+MobX does support observable arrays, observable
+objects and observable maps, so those _can_ be observed for changes by
+a React component. We demonstrate that here with `animals`:
+
+```tsx
+import { Component } from 'react'
+import { observer } from 'mobx-react'
+
+const AnimalsView = observer(({ animals }: { animals: Animal[] }) => {
+  return (
+    <ul>
+      {animals.map(animal => (
+        <ul>
+          <AnimalView key={animal.name} animal={animal} />
+        </ul>
+      ))}
+    </ul>
+  )
+})
+```
+
+If we invoke this with an observable array of animals, the React component
+automatically re-renders each time the array changes (by adding or removing
+items) or if any item in that array itself changes.
+
+Instances of our
+`Zoo` class have an `animals` property that is observable, so let's use
+that:
+
+```tsx
+const wilma = new Animal('Wilma', 'penguin')
+
+const zoo = new Zoo()
+zoo.addAnimal(fred)
+zoo.addAnimal(wilma)
+```
+
+We can now render our animals:
+
+```tsx
+<AnimalsView animals={zoo.animals} />
+```

--- a/content/basics/basics.mdx
+++ b/content/basics/basics.mdx
@@ -171,9 +171,8 @@ If we invoke this with an observable array of animals, the React component
 automatically re-renders each time the array changes (by adding or removing
 items) or if any item in that array itself changes.
 
-Instances of our
-`Zoo` class have an `animals` property that is observable, so let's use
-that:
+Instances of our `Zoo` class have an `animals` property that is observable, so
+let's use that:
 
 ```tsx
 const wilma = new Animal('Wilma', 'penguin')

--- a/content/basics/basics.mdx
+++ b/content/basics/basics.mdx
@@ -7,17 +7,16 @@ import { Playground } from 'docz'
 
 # Basic Introduction
 
-[MobX](https://mobx.js.org/README.html) lets you create observable state. This
-library, `mobx-react` integrates it with React. It provides a way for you to
-create React components that respond to MobX state changes.
+[MobX](https://mobx.js.org) lets you create observable state. This library,
+`mobx-react` integrates it with React. It provides a way for you to make React
+components respond to MobX state changes.
 
 > Frameworks such as [mobx-state-tree](https://mobx-state-tree.js.org) and
 > [mobx-keystone](https://mobx-keystone.js.org/) build on
 > top of MobX to offer a higher-level way to create observable models. These models
 > give you additional properties, such as automatic serialization to JSON. This
-> introduction uses plain MobX models. The principles of React
-> integration are the same for these advanced libraries are the same
-> as they are also built with MobX.
+> introduction uses plain MobX models. Because these advanced libraries are
+> also built with MobX, the principles for React integration are the same.
 
 ## MobX models
 
@@ -207,13 +206,19 @@ this case by using `Zoo.addAnimal`. The individual `AnimalView` re-renders
 itself as before when any observed properties the underlying object change,
 which in this case is its `isHungry` status.
 
+Be aware that if you forget to wrap `AnimalsView` with `observer` it won't be
+able to detect when you add (or remove) from the array, even if the parent
+React component that uses `AnimalsView` is itself wrapped with `observer`. So
+as mentioned previously, don't worry and just use `observer` for all your
+components!
+
 ## Local component state with `useLocalStore`
 
 So far we have discussed observable model state, where the models live outside
-of the React components. It is useful to have component-specific state however.
-This is state that only makes sense within that component, is typically very UI
-specific, and there is no reason to specify this part of your application's
-models.
+of the React components. It is often useful to have component-specific state as
+well. Component-specific state is state that only makes sense within that React
+component. It is typically very UI specific, and there is no reason to make
+this state part of your application's models.
 
 This is useful for "temporary data", such as for instance the text that a user
 is currently entering into an input widget. If the user then performs a special
@@ -224,6 +229,11 @@ all your state this way.
 This is the MobX equivalent of component state as you'd use with the `useState`
 hook or the `setState` method in case of class components. Unlike React the
 `useState` hook, the MobX local store is observable.
+
+Just like React's `useState` you can actually pass component-specific state
+down to child components or set it up as a React Context -- it doesn't
+_have_ to be restricted to this component only. You could set up an entire
+application using `useLocalStore` only.
 
 Here is an example where we add an animal to a zoo using a form:
 
@@ -311,17 +321,12 @@ Where does `AnimalsView` get its `animals` prop from? From the `zoo` in
 `ZooView`. Where does `AnimalView` get its `animal` prop? From the each animal
 in the `AnimalsView`. We also pass `zoo` into `AddAnimalView` directly.
 
-But where would we put the `zoo`? One simple approach is to make it a global in
-your application, and simply import it when you need it.
+We recommend using props to pass instances around to the React components that
+need them. It ensures your components are loosely-coupled, and it makes it
+easier to write an automated test for them.
 
-Often this is sufficient. Consider a `Locale` MobX model that describes information
-about your site's Locale. You can simply maintain the current locale as
-a global and import it wherever you need it.
-
-As an alternative you can create an observable model as part of component state
-and then pass it along as a prop.
-
-If you need to have access to a MobX model instance in many components but you
-still want different sections of your UI to use a _different_ instance, you can
-pass in a MobX model instance with [React's context
-mechanism](https://reactjs.org/docs/context.html).
+But it has to start somewhere. Where would we put `zoo`? One simple approach is
+to make it a global in your application, and simply import it when you need it
+at the top of your React application. Frameworks like `mobx-state-tree` and
+`mobx-keystone` offer more sophisticated patterns to maintain such a root
+store.

--- a/content/getting_started/getting_started.mdx
+++ b/content/getting_started/getting_started.mdx
@@ -8,8 +8,8 @@ import { Playground } from 'docz'
 # Basic Introduction
 
 [MobX](https://mobx.js.org) lets you create observable state. This library,
-`mobx-react` integrates it with React. It provides a way for you to make React
-components respond to MobX state changes.
+`mobx-react`, provides bindings to make React components respond to MobX
+state changes.
 
 > Frameworks such as [mobx-state-tree](https://mobx-state-tree.js.org) and
 > [mobx-keystone](https://mobx-keystone.js.org/) build on
@@ -110,7 +110,7 @@ The only special thing that `AnimalView` does compared to a normal React
 function component is that it is wrapped in `observer` from `mobx-react`. This
 makes `AnimalView` automatically re-render itself if anything that it observes
 changes. In this case the observable information is the computed property
-`isHungry`, which in turn it based on the observable property `energy`.
+`isHungry`, which in turn is based on the observable property `energy`.
 `AnimalView` automatically re-renders itself only if `isHungry` changes. You
 don't need to do anything else to make that happen.
 

--- a/content/getting_started/getting_started.mdx
+++ b/content/getting_started/getting_started.mdx
@@ -1,6 +1,6 @@
 ---
-name: Basics
-route: /basics
+name: Getting Started
+route: /getting_started
 ---
 
 import { Playground } from 'docz'

--- a/doczrc.js
+++ b/doczrc.js
@@ -30,5 +30,6 @@ export default {
       blockquoteBg: '#0C1021',
     },
   },
+  menu: ['Introduction', 'Basics', 'Libraries'],
   plugins: [doczPluginNetlify()],
 }


### PR DESCRIPTION
As discussed in issue https://github.com/mobxjs/mobx-react-docz/issues/99
the documention at present shows a great deal of options but is not very friendly for beginners (or as a quick refresher). This is a first stab at such documentation.

I'm not happy with the name "Basics" but the name "Introduction" is already in use. Perhaps we can rename that to make this the real introduction.

I'm also not happy that I couldn't actually test the code I wrote without copying them all into a separate file; I haven't found a file inclusion mechanism yet for code snippets. So the inline code is
all untested at present. :(  

Docz (v2?) offers a Playground component which comes close, but focuses on React and I'm not sure what to do about model code then.
